### PR TITLE
RWA-49f: Enable mutation tests to run overnight

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -8,7 +8,10 @@ properties([
 @Library("Infrastructure")
 
 def type = "java"
-def product = "rpe"
-def component = "spring-boot-template"
+def product = "wa"
+def component = "case-event-handler"
 
-withNightlyPipeline(type, product, component) {}
+withNightlyPipeline(type, product, component) {
+    enableMutationTest()
+    enableSlackNotifications('#wa-build')
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-49

### Change description ###

Enable Mutation tests to run overnight.
Enable slack notifications to be sent to #wa-build channel

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
