### PR TITLE
Fix CVE-2021-29425

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,6 +205,7 @@ dependencyManagement {
       entry 'guava'
     }
     dependency group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
+    dependency group: 'commons-io', name: 'commons-io', version: '2.8.0'
   }
 }
 


### PR DESCRIPTION



### JIRA link (if applicable) ###



### Change description ###

Fix CVE-2021-29425, Updated commons-io dependency to latest version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
