### PR TITLE
RWA-925 - Consume messages from the ASB topic(s) & enqueue for insertion

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/wacaseeventhandler/controllers/CaseEventHandlerControllerHandlersOrderTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wacaseeventhandler/controllers/CaseEventHandlerControllerHandlersOrderTest.java
@@ -85,8 +85,8 @@ class CaseEventHandlerControllerHandlersOrderTest {
 
         InOrder inOrder = inOrder(
             cancellationTaskHandlerService,
-            initiationTaskHandlerService,
-            warningTaskHandlerService
+            warningTaskHandlerService,
+            initiationTaskHandlerService
         );
 
 

--- a/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventConsumer.java
@@ -17,15 +17,15 @@ import uk.gov.hmcts.reform.wacaseeventhandler.services.ccd.CcdEventProcessor;
 @Scope("prototype")
 @ConditionalOnProperty("azure.servicebus.enableASB")
 @SuppressWarnings("PMD.DoNotUseThreads")
-public class CcdEventConsumer implements Runnable {
+public class CaseEventConsumer implements Runnable {
 
     private final ServiceBusConfiguration serviceBusConfiguration;
     private final CcdEventProcessor ccdEventProcessor;
     private final CcdEventErrorHandler ccdEventErrorHandler;
 
-    public CcdEventConsumer(ServiceBusConfiguration serviceBusConfiguration,
-                            CcdEventProcessor ccdEventProcessor,
-                            CcdEventErrorHandler ccdEventErrorHandler
+    public CaseEventConsumer(ServiceBusConfiguration serviceBusConfiguration,
+                             CcdEventProcessor ccdEventProcessor,
+                             CcdEventErrorHandler ccdEventErrorHandler
     ) {
         this.serviceBusConfiguration = serviceBusConfiguration;
         this.ccdEventProcessor = ccdEventProcessor;

--- a/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventDeadLetterQueueConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventDeadLetterQueueConsumer.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.wacaseeventhandler.clients;
+
+import com.azure.messaging.servicebus.ServiceBusReceiverClient;
+import com.azure.messaging.servicebus.ServiceBusSessionReceiverClient;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import uk.gov.hmcts.reform.wacaseeventhandler.config.ServiceBusConfiguration;
+import uk.gov.hmcts.reform.wacaseeventhandler.services.MessageReceiver;
+import uk.gov.hmcts.reform.wacaseeventhandler.services.ccd.CcdEventErrorHandler;
+
+@Slf4j
+@Component
+@Scope("prototype")
+@ConditionalOnProperty("azure.servicebus.enableASB")
+@SuppressWarnings("PMD.DoNotUseThreads")
+public class CaseEventDeadLetterQueueConsumer implements Runnable {
+
+    private final ServiceBusConfiguration serviceBusConfiguration;
+    private final CcdEventErrorHandler ccdEventErrorHandler;
+    private final MessageReceiver messageReceiver;
+
+    public CaseEventDeadLetterQueueConsumer(ServiceBusConfiguration serviceBusConfiguration,
+                                            CcdEventErrorHandler ccdEventErrorHandler,
+                                            MessageReceiver messageReceiver
+    ) {
+        this.serviceBusConfiguration = serviceBusConfiguration;
+        this.ccdEventErrorHandler = ccdEventErrorHandler;
+        this.messageReceiver = messageReceiver;
+    }
+
+    @Override
+    @SuppressWarnings("squid:S2189")
+    public void run() {
+        try (ServiceBusSessionReceiverClient sessionReceiver
+                     = serviceBusConfiguration.createDeadLetterQueueSessionReceiver()) {
+            while (true) {
+                consumeMessage(sessionReceiver);
+            }
+        }
+    }
+
+    @SuppressWarnings({"PMD.DataflowAnomalyAnalysis"})
+    protected void consumeMessage(ServiceBusSessionReceiverClient sessionReceiver) {
+        try (ServiceBusReceiverClient receiver = sessionReceiver.acceptNextSession()) {
+            receiver.receiveMessages(1)
+                .forEach(
+                    message -> {
+
+                        String incomingMessage = new String(message.getBody().toBytes());
+                        try {
+                            log.info("Received DLQ message with id '{}'", message.getMessageId());
+
+                            messageReceiver.processCaseEventDeadLetterQueue(incomingMessage);
+
+                            receiver.complete(message);
+
+                            log.info("DLQ Message with id '{}' handled successfully", message.getMessageId());
+                        } catch (JsonProcessingException ex) {
+                            ccdEventErrorHandler.handleJsonError(receiver, message, ex);
+                        } catch (RestClientException ex) {
+                            ccdEventErrorHandler.handleApplicationError(receiver, message, ex);
+                        } catch (Exception ex) {
+                            ccdEventErrorHandler.handleGenericError(receiver, message, ex);
+                        }
+                    });
+        } catch (IllegalStateException ex) {
+            log.info("Timeout: No DLQ messages received, waiting for next session.");
+        } catch (Exception ex) {
+            log.error("Error occurred while closing the session", ex);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/config/CaseEventDeadLetterQueueExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/config/CaseEventDeadLetterQueueExecutor.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.reform.wacaseeventhandler.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import uk.gov.hmcts.reform.wacaseeventhandler.clients.CaseEventDeadLetterQueueConsumer;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+@Configuration
+@ConditionalOnProperty("azure.servicebus.enableASB")
+public class CaseEventDeadLetterQueueExecutor {
+
+    @Value("${azure.servicebus.threads}")
+    private int concurrentSessions;
+
+    @Autowired
+    private CaseEventDeadLetterQueueConsumer serviceBusTask;
+
+    @Bean
+    @SuppressWarnings("PMD.DataflowAnomalyAnalysis")
+    public void createServiceBus() {
+        final ExecutorService executorService = Executors.newFixedThreadPool(
+            Integer.valueOf(concurrentSessions));
+
+        IntStream.range(0, concurrentSessions).forEach(
+            task -> executorService.execute(serviceBusTask));
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/config/CcdEventExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/config/CcdEventExecutor.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import uk.gov.hmcts.reform.wacaseeventhandler.clients.CcdEventConsumer;
+import uk.gov.hmcts.reform.wacaseeventhandler.clients.CaseEventConsumer;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -19,7 +19,7 @@ public class CcdEventExecutor {
     private int concurrentSessions;
 
     @Autowired
-    private CcdEventConsumer serviceBusTask;
+    private CaseEventConsumer serviceBusTask;
 
     @Bean
     @SuppressWarnings("PMD.DataflowAnomalyAnalysis")

--- a/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/config/ServiceBusConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/config/ServiceBusConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.wacaseeventhandler.config;
 import com.azure.core.amqp.AmqpRetryOptions;
 import com.azure.messaging.servicebus.ServiceBusClientBuilder;
 import com.azure.messaging.servicebus.ServiceBusSessionReceiverClient;
+import com.azure.messaging.servicebus.models.SubQueue;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -37,6 +38,21 @@ public class ServiceBusConfiguration {
             .buildClient();
 
         log.info("Session receiver created, successfully");
+        return client;
+    }
+
+    public ServiceBusSessionReceiverClient createDeadLetterQueueSessionReceiver() {
+        log.info("Creating Dead Letter Queue Session receiver");
+        ServiceBusSessionReceiverClient client = new ServiceBusClientBuilder()
+                .connectionString(connectionString)
+                .retryOptions(retryOptions())
+                .sessionReceiver()
+                .topicName(topicName)
+                .subQueue(SubQueue.DEAD_LETTER_QUEUE)
+                .subscriptionName(subscriptionName)
+                .buildClient();
+
+        log.info("DLQ Session receiver created, successfully");
         return client;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/services/MessageReceiver.java
+++ b/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/services/MessageReceiver.java
@@ -16,10 +16,12 @@ public class MessageReceiver {
         this.objectMapper = objectMapper;
     }
 
+    @SuppressWarnings({"PMD.UnusedLocalVariable", "PMD.DataflowAnomalyAnalysis"})
     public void processCaseEvent(String message) throws JsonProcessingException {
         final EventInformation caseEventInformation = createEventInformation(message, "Case Event");
     }
 
+    @SuppressWarnings({"PMD.UnusedLocalVariable", "PMD.DataflowAnomalyAnalysis"})
     public void processCaseEventDeadLetterQueue(String message) throws JsonProcessingException {
         final EventInformation caseEventDlqInformation = createEventInformation(message,
                 "Case Event Dead Letter Queue");

--- a/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/services/MessageReceiver.java
+++ b/src/main/java/uk/gov/hmcts/reform/wacaseeventhandler/services/MessageReceiver.java
@@ -1,0 +1,52 @@
+package uk.gov.hmcts.reform.wacaseeventhandler.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.wacaseeventhandler.domain.ccd.message.EventInformation;
+
+@Slf4j
+@Service
+public class MessageReceiver {
+
+    private final ObjectMapper objectMapper;
+
+    public MessageReceiver(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void processCaseEvent(String message) throws JsonProcessingException {
+        final EventInformation caseEventInformation = createEventInformation(message, "Case Event");
+    }
+
+    public void processCaseEventDeadLetterQueue(String message) throws JsonProcessingException {
+        final EventInformation caseEventDlqInformation = createEventInformation(message,
+                "Case Event Dead Letter Queue");
+    }
+
+    private EventInformation createEventInformation(String message, String eventName) throws JsonProcessingException {
+        EventInformation eventInformation = objectMapper.readValue(message, EventInformation.class);
+
+        log.info(
+                "{} details:\n"
+                        + "Case id: '{}'\n"
+                        + "Event id: '{}'\n"
+                        + "New state id: '{}'\n"
+                        + "Previous state id: '{}'\n"
+                        + "Jurisdiction id: '{}'\n"
+                        + "Case type id: '{}'",
+                eventName,
+                eventInformation.getCaseId(),
+                eventInformation.getEventId(),
+                eventInformation.getNewStateId(),
+                eventInformation.getPreviousStateId(),
+                eventInformation.getJurisdictionId(),
+                eventInformation.getCaseTypeId()
+        );
+
+        return eventInformation;
+    }
+
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventConsumerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventConsumerTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class CcdEventConsumerTest {
+class CaseEventConsumerTest {
 
     @Mock
     private ServiceBusConfiguration serviceBusConfiguration;
@@ -43,11 +43,11 @@ class CcdEventConsumerTest {
     @Mock
     private CcdEventErrorHandler ccdEventErrorHandler;
 
-    private CcdEventConsumer underTest;
+    private CaseEventConsumer underTest;
 
     @BeforeEach
     void setUp() {
-        underTest = new CcdEventConsumer(serviceBusConfiguration, processor,
+        underTest = new CaseEventConsumer(serviceBusConfiguration, processor,
             ccdEventErrorHandler
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventDeadLetterConsumerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/wacaseeventhandler/clients/CaseEventDeadLetterConsumerTest.java
@@ -1,0 +1,149 @@
+package uk.gov.hmcts.reform.wacaseeventhandler.clients;
+
+import com.azure.core.util.BinaryData;
+import com.azure.core.util.IterableStream;
+import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
+import com.azure.messaging.servicebus.ServiceBusReceiverClient;
+import com.azure.messaging.servicebus.ServiceBusSessionReceiverClient;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClientException;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+import uk.gov.hmcts.reform.wacaseeventhandler.config.ServiceBusConfiguration;
+import uk.gov.hmcts.reform.wacaseeventhandler.services.MessageReceiver;
+import uk.gov.hmcts.reform.wacaseeventhandler.services.ccd.CcdEventErrorHandler;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CaseEventDeadLetterConsumerTest {
+
+    @Mock
+    private ServiceBusConfiguration serviceBusConfiguration;
+    @Mock
+    private ServiceBusSessionReceiverClient sessionReceiverClient;
+    @Mock
+    private ServiceBusReceiverClient receiverClient;
+    @Mock
+    private ServiceBusReceivedMessage receivedMessage;
+    @Mock
+    private CcdEventErrorHandler ccdEventErrorHandler;
+    @Mock
+    private MessageReceiver messageReceiver;
+
+    private CaseEventDeadLetterQueueConsumer underTest;
+
+    private static final String TEST_MESSAGE =  "testMessage";
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CaseEventDeadLetterQueueConsumer(serviceBusConfiguration,
+                    ccdEventErrorHandler,
+                    messageReceiver
+        );
+    }
+
+    @Test
+    void given_session_is_accepted_when_receiver_throws_error() throws IOException {
+        when(sessionReceiverClient.acceptNextSession()).thenThrow(IllegalStateException.class);
+
+        underTest.consumeMessage(sessionReceiverClient);
+
+        verify(messageReceiver, Mockito.times(0)).processCaseEventDeadLetterQueue(TEST_MESSAGE);
+        verify(receiverClient, Mockito.times(0)).complete(receivedMessage);
+        verify(receiverClient, Mockito.times(0)).abandon(any());
+        verify(receiverClient, Mockito.times(0)).deadLetter(any(), any());
+    }
+
+    @Test
+    void given_session_is_accepted_when_message_is_consumed() throws IOException {
+        publishMessageToReceiver();
+
+        doNothing().when(messageReceiver).processCaseEventDeadLetterQueue(any());
+
+        doNothing().when(receiverClient).complete(receivedMessage);
+
+        underTest.consumeMessage(sessionReceiverClient);
+
+        verify(messageReceiver, Mockito.times(1)).processCaseEventDeadLetterQueue(TEST_MESSAGE);
+        verify(receiverClient, Mockito.times(1)).complete(receivedMessage);
+    }
+
+    @Test
+    void given_session_is_accepted_when_invalid_message_consumed() throws IOException {
+        publishMessageToReceiver();
+
+        doThrow(JsonProcessingException.class).when(messageReceiver).processCaseEventDeadLetterQueue(any());
+
+        doNothing().when(ccdEventErrorHandler).handleJsonError(any(), any(), any());
+        underTest.consumeMessage(sessionReceiverClient);
+
+        verify(messageReceiver, Mockito.times(1)).processCaseEventDeadLetterQueue(TEST_MESSAGE);
+        verify(ccdEventErrorHandler, Mockito.times(1))
+            .handleJsonError(any(), any(), any());
+        verify(ccdEventErrorHandler, Mockito.times(0))
+            .handleApplicationError(any(), any(), any());
+        verify(ccdEventErrorHandler, Mockito.times(0))
+            .handleGenericError(any(), any(), any());
+    }
+
+    @Test
+    void given_session_is_accepted_when_exception_thrown_from_downstream() throws IOException {
+        publishMessageToReceiver();
+
+        doThrow(RestClientException.class).when(messageReceiver).processCaseEventDeadLetterQueue(any());
+
+        underTest.consumeMessage(sessionReceiverClient);
+
+        verify(messageReceiver, Mockito.times(1)).processCaseEventDeadLetterQueue(TEST_MESSAGE);
+        verify(ccdEventErrorHandler, Mockito.times(0))
+            .handleJsonError(any(), any(), any());
+        verify(ccdEventErrorHandler, Mockito.times(1))
+            .handleApplicationError(any(), any(), any());
+        verify(ccdEventErrorHandler, Mockito.times(0))
+            .handleGenericError(any(), any(), any());
+    }
+
+    @Test
+    void given_session_is_accepted_when_unknown_exception_thrown_from_application() throws IOException {
+        publishMessageToReceiver();
+
+        doThrow(NullPointerException.class).when(messageReceiver).processCaseEventDeadLetterQueue(any());
+
+        underTest.consumeMessage(sessionReceiverClient);
+
+        verify(messageReceiver, Mockito.times(1)).processCaseEventDeadLetterQueue(TEST_MESSAGE);
+        verify(ccdEventErrorHandler, Mockito.times(0))
+            .handleJsonError(any(), any(), any());
+        verify(ccdEventErrorHandler, Mockito.times(0))
+            .handleApplicationError(any(), any(), any());
+        verify(ccdEventErrorHandler, Mockito.times(1))
+            .handleGenericError(any(), any(), any());
+    }
+
+    private void publishMessageToReceiver() {
+        when(sessionReceiverClient.acceptNextSession()).thenReturn(receiverClient);
+        when(receivedMessage.getBody()).thenReturn(BinaryData.fromBytes(TEST_MESSAGE.getBytes()));
+
+        final Flux<ServiceBusReceivedMessage> iterableStreamFlux = Flux.<ServiceBusReceivedMessage>create(
+            sink -> {
+                sink.next(receivedMessage);
+                sink.complete();
+            }).subscribeOn(Schedulers.single());
+
+        when(receiverClient.receiveMessages(1)).thenReturn(new IterableStream<>(iterableStreamFlux));
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RWA-925 Consume messages from the ASB topic(s) & enqueue for insertion](https://tools.hmcts.net/jira/browse/RWA-925)

### Change description ###

Enable receiving of messages from the ASB topic(s) (the normal one and the newly build DLQ one) then pass those messages on to a message receiver.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
