### PR TITLE
RWA-1300 Fix multiple CVE spring boot upgrade to 2.6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.6.4'
+  id 'org.springframework.boot' version '2.6.6'
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
@@ -246,7 +246,7 @@ dependencyManagement {
       entry 'netty-resolver-dns'
       entry 'netty-resolver-dns-native-macos'
     }
-    
+
     dependencySet(group: 'org.seleniumhq.selenium', version: '4.1.2'){
       entry 'selenium-java'
       entry 'selenium-remote-driver'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,74 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2030-01-01">
-        <notes><![CDATA[
-     Suppressing as it's a false positive (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
-        <gav regex="true">^org.springframework.security:spring-security-*.*</gav>
-        <cpe>cpe:/a:pivotal_software:spring_security</cpe>
-        <cve>CVE-2018-1258</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our spring boot version needs to be updated
-   ]]></notes>
-        <cve>CVE-2021-22060</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our spring boot version needs to be updated
-   ]]></notes>
-        <cve>CVE-2018-1258</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our spring security version needs to be updated
-   ]]></notes>
-        <cve>CVE-2021-22112</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our open feign version needs to be updated
-   ]]></notes>
-        <cve>CVE-2021-22044</cve>
-    </suppress>
-    <suppress until="2022-03-01">
-        <notes><![CDATA[
-     Suppressing as our open feign version needs to be updated
-   ]]></notes>
-        <cve>CVE-2021-43797</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
-   file name: spring-security-core-5.4.9.jar
-   ]]></notes>
-        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-core@.*$</packageUrl>
-        <vulnerabilityName>CWE-862: Missing Authorization</vulnerabilityName>
-    </suppress>
-    <suppress>
-        <notes>Additional Log Injection in Spring Framework</notes>
-        <cve>CVE-2021-22060</cve>
-    </suppress>
-    <suppress>
-        <notes>Unauthorized Access with Spring Security Method Security</notes>
-        <cve>CVE-2018-1258</cve>
-    </suppress>
-    <suppress>
-        <notes>Changing SecurityContext More Than Once in Single Request Can Fail to Save</notes>
-        <cve>CVE-2021-22112</cve>
-    </suppress>
-    <suppress>
-        <notes>Spring Cloud OpenFeign Client Endpoint Exposure</notes>
-        <cve>CVE-2021-22044</cve>
-    </suppress>
-    <suppress until="2022-05-01">
-        <notes><![CDATA[
-   file name: jackson-databind-2.13.1.jar
-   ]]> will solve version: '2.13.2.1'
-        </notes>
-        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
-        <cve>CVE-2020-36518</cve>
-    </suppress>
   <suppress until="2022-05-01">
     <notes><![CDATA[
    file name: postgresql-42.3.1.jar
@@ -82,10 +13,5 @@
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
     <cve>CVE-2022-21724</cve>
-  </suppress>
-  <suppress until="2022-05-01">
-    <notes><![CDATA[ file name: spring-beans-5.3.16.jar ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring-beans@.*$</packageUrl>
-    <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -83,4 +83,9 @@
     <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
     <cve>CVE-2022-21724</cve>
   </suppress>
+  <suppress until="2022-05-01">
+    <notes><![CDATA[ file name: spring-beans-5.3.16.jar ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.springframework/spring-beans@.*$</packageUrl>
+    <vulnerabilityName>CVE-2022-22965</vulnerabilityName>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-1300

### Change description ###

Address CVE-2022-22950 and CVE-2022-22965. Removed suppressions that are no longer needed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
