### PR TITLE
RWA-1350: upgraded postgresql jdbc driver to 42.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.0'
-  id 'info.solidsoft.pitest' version '1.5.2'
+  id 'info.solidsoft.pitest' version '1.7.4'
   id 'io.freefair.lombok' version '5.3.3.3'
 }
 
@@ -118,7 +118,7 @@ task tests {
 }
 
 task fortifyScan(type: JavaExec) {
-  main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
+  mainClass = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
 }
@@ -141,8 +141,8 @@ pmd {
 jacocoTestReport {
   executionData(test, integration)
   reports {
-    xml.enabled = true
-    csv.enabled = false
+    xml.required = true
+    csv.required = false
     xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }
@@ -273,7 +273,7 @@ def versions = [
   springDoc    : '1.6.6',
   springBoot   : '2.6.3',
   serenity     : '3.1.20',
-  pitest       : '1.5.2',
+  pitest       : '1.7.4',
   logbook      : '2.6.2',
   tomcat       : '9.0.58',
   log4j        : '2.17.1'
@@ -366,7 +366,7 @@ dependencies {
 
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.3'
 
-  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.3.1'
+  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.3.4'
 }
 
 mainClassName = 'uk.gov.hmcts.reform.wacaseeventhandler.Application'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,17 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2022-05-01">
-    <notes><![CDATA[
-   file name: postgresql-42.3.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-    <cve>CVE-2022-26520</cve>
-  </suppress>
-  <suppress until="2022-05-01">
-    <notes><![CDATA[
-   file name: postgresql-42.3.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.postgresql/postgresql@.*$</packageUrl>
-    <cve>CVE-2022-21724</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1350


### Change description ###
upgraded postgresql jdbc driver to 42.3.4 (CVE-2022-21724, CVE-2022-26520)
changed deprecated features in build.gradle
upgraded pitest to 1.7.4 to get rid of gradle deprecation warning


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
