### PR TITLE
RWA-1382: upgraded launchdarkly-java-server-sdk due to CVE-2022-25647

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,11 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.6.7'
   id 'org.owasp.dependencycheck' version '7.1.0.1'
-  id 'com.github.ben-manes.versions' version '0.36.0'
+  id 'uk.gov.hmcts.java' version '0.12.5'
+  id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.0'
   id 'info.solidsoft.pitest' version '1.7.4'
   id 'io.freefair.lombok' version '5.3.3.3'
-  id 'uk.gov.hmcts.java' version '0.12.5'
-
 }
 
 apply plugin: 'net.serenity-bdd.aggregator'

--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,12 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.6.7'
   id 'org.owasp.dependencycheck' version '7.1.0.1'
-  id 'uk.gov.hmcts.java' version '0.12.5'
-  id 'com.github.ben-manes.versions' version '0.38.0'
+  id 'com.github.ben-manes.versions' version '0.36.0'
   id 'org.sonarqube' version '3.0'
   id 'info.solidsoft.pitest' version '1.7.4'
   id 'io.freefair.lombok' version '5.3.3.3'
+  id 'uk.gov.hmcts.java' version '0.12.5'
+
 }
 
 apply plugin: 'net.serenity-bdd.aggregator'
@@ -77,6 +78,7 @@ tasks.withType(JavaCompile) {
 
 tasks.withType(Test) {
   useJUnitPlatform()
+
   testLogging {
     exceptionFormat = 'full'
   }
@@ -322,7 +324,7 @@ dependencies {
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
   implementation 'org.camunda.bpm:camunda-external-task-client:7.17.0'
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.2.2'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.8.1'
   implementation 'org.apache.commons:commons-lang3:3.12.0'
 
   testImplementation libraries.junit5


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1382


### Change description ###
upgraded launchdarkly-java-server-sdk due to CVE-2022-25647


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
