### PR TITLE
RWA-1508: CVE-2022-22978 suppression (false positive)

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,4 +14,10 @@
     <notes>False positive spring-security-crypto-5.7.1.jar</notes>
     <cve>CVE-2020-5408</cve>
   </suppress>
+  <suppress>
+    <notes>CVE-2022-22978 suppression (false positive), because spring security already at higher level (5.7.1) than vulnerable versions
+      (5.5.x prior to 5.5.7, 5.6.x prior to 5.6.4)
+      https://tanzu.vmware.com/security/cve-2022-22978</notes>
+    <cve>CVE-2022-22978</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1508


### Change description ###
CVE-2022-22978 suppression (false positive), because spring security already at higher level (5.7.1) than vulnerable versions (5.5.x prior to 5.5.7, 5.6.x prior to 5.6.4)
https://tanzu.vmware.com/security/cve-2022-22978

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
