### PR TITLE
RWA-1751: CVE-2022-25857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,6 +296,8 @@ ext.libraries = [
   ]
 ]
 
+ext['snakeyaml.version'] = '1.31'
+
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -32,4 +32,11 @@
     <notes>False positive (https://github.com/jeremylong/DependencyCheck/issues/4671)</notes>
     <cve>CVE-2022-31569</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: launchdarkly-java-server-sdk-5.8.1.jar (shaded: org.yaml:snakeyaml:1.26)
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
+    <cve>CVE-2022-25857</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -33,9 +33,7 @@
     <cve>CVE-2022-31569</cve>
   </suppress>
   <suppress>
-    <notes><![CDATA[
-   file name: launchdarkly-java-server-sdk-5.8.1.jar (shaded: org.yaml:snakeyaml:1.26)
-   ]]></notes>
+    <notes>Suppressed due to unavailability of updated version of aunchdarkly-java-server-sdk</notes>
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-25857</cve>
   </suppress>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1751


### Change description ###
RWA-1751: upgrade snakeyaml to 1.31 to CVE-2022-25857, 
added suppressions for launchdarkly-java-server-sdk-5.8.1.jar cve issue


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
