### PR TITLE
RWA-1776: Upgraded launchdarkly-java-server-sdk

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.0'
-  id 'org.owasp.dependencycheck' version '7.1.0.1'
+  id 'org.owasp.dependencycheck' version '7.1.2'
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.0'
@@ -332,7 +332,7 @@ dependencies {
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
   implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.17.0'
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.0'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.1'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
   testImplementation libraries.junit5

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,19 +24,4 @@
     <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
     <cve>CVE-2022-34305</cve>
   </suppress>
-  <suppress>
-    <notes>False positive log4j-api-2.17.2.jar and log4j-to-slf4j-2.17.2.jar</notes>
-    <cve>CVE-2022-33915</cve>
-  </suppress>
-  <suppress>
-    <notes>False positive (https://github.com/jeremylong/DependencyCheck/issues/4671)</notes>
-    <cve>CVE-2022-31569</cve>
-  </suppress>
-
-  <suppress>
-    <notes>Suppressed due to unavailability of updated version of aunchdarkly-java-server-sdk</notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2022-25857</cve>
-
-  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,4 +24,8 @@
     <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
     <cve>CVE-2022-34305</cve>
   </suppress>
+  <suppress>
+    <notes>Suppressed until new version available (https://bitbucket.org/snakeyaml/snakeyaml/issues/531/stackoverflow-oss-fuzz-47081)</notes>
+    <cve>CVE-2022-38752</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1776


### Change description ###
Upgraded launchdarkly-java-server-sdk due to CVE-2022-38749, CVE-2022-38751, CVE-2022-38750


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
