### PR TITLE
Rwa 1828

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.7.0'
-  id 'org.owasp.dependencycheck' version '7.1.2'
+  id 'org.springframework.boot' version '2.7.4'
+  id 'org.owasp.dependencycheck' version '7.2.1'
   id 'uk.gov.hmcts.java' version '0.12.5'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.0'
@@ -209,7 +209,6 @@ dependencyCheck {
     assemblyEnabled = false
   }
 }
-ext['snakeyaml.version'] = '1.31'
 dependencyManagement {
   dependencies {
     dependency group: 'com.github.docker-java', name: 'docker-java', version: '3.2.13'
@@ -279,7 +278,7 @@ def versions = [
   junitPlatform: '1.8.2',
   reformLogging: '5.1.9',
   springDoc    : '1.6.6',
-  springBoot   : '2.7.3',
+  springBoot   : '2.7.4',
   serenity     : '3.1.20',
   pitest       : '1.7.4',
   logbook      : '2.6.2',
@@ -297,7 +296,7 @@ ext.libraries = [
   ]
 ]
 
-ext['snakeyaml.version'] = '1.31'
+ext['snakeyaml.version'] = '1.33'
 
 dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
@@ -333,7 +332,7 @@ dependencies {
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
   implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.17.0'
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.1'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.2'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
   testImplementation libraries.junit5

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,4 +24,12 @@
     <notes>Not affected by this cve (https://lists.apache.org/thread/k04zk0nq6w57m72w5gb0r6z9ryhmvr4k)</notes>
     <cve>CVE-2022-34305</cve>
   </suppress>
+  <suppress>
+    <notes>False positive launchdarkly-java-server-sdk-5.10.2.jar</notes>
+    <cve>CVE-2022-38751</cve>
+  </suppress>
+  <suppress>
+    <notes>False positive launchdarkly-java-server-sdk-5.10.2.jar and snakeyaml-1.33.jar</notes>
+    <cve>CVE-2022-38752</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-1828

### Change description ###

dependency-check - upgrade launchdarkly-java-server-sdk to 5.10.2, springframework.boot to 2.7.4, dependencycheck to 7.2.1 and snakeyaml to 1.33. Suppression of CVE-2022-38751 and CVE-2022-38752 due to false positive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
