### PR TITLE
RWA-1916 empty caseEventMessages before tests

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/wacaseeventhandler/AsbMessagesToDatabaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wacaseeventhandler/AsbMessagesToDatabaseTest.java
@@ -1,9 +1,9 @@
 package uk.gov.hmcts.reform.wacaseeventhandler;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import uk.gov.hmcts.reform.wacaseeventhandler.domain.ccd.message.EventInformation;
 import uk.gov.hmcts.reform.wacaseeventhandler.domain.model.CaseEventMessage;
 import uk.gov.hmcts.reform.wacaseeventhandler.domain.model.EventMessageQueryResponse;
@@ -21,14 +21,14 @@ import static org.awaitility.Awaitility.await;
 
 public class AsbMessagesToDatabaseTest extends MessagingTests {
 
-    public static List<CaseEventMessage> caseEventMessages = new ArrayList<>();
+    public static List<CaseEventMessage> caseEventMessages;
 
-    @After
+    @AfterEach
     public void tearDown() {
         deleteMessagesFromDatabase(caseEventMessages);
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         caseEventMessages = new ArrayList<>();
     }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wacaseeventhandler/AsbMessagesToDatabaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wacaseeventhandler/AsbMessagesToDatabaseTest.java
@@ -99,7 +99,7 @@ public class AsbMessagesToDatabaseTest extends MessagingTests {
             .until(() -> {
                 final EventMessageQueryResponse dlqMessagesFromDb = getMessagesFromDb(caseId, false);
                 if (dlqMessagesFromDb != null) {
-                    final List<CaseEventMessage> caseEventMessages = dlqMessagesFromDb.getCaseEventMessages();
+                    caseEventMessages = dlqMessagesFromDb.getCaseEventMessages();
 
                     Assertions.assertEquals(1, caseEventMessages.size());
                     Assertions.assertEquals(MessageState.UNPROCESSABLE, caseEventMessages.get(0).getState());

--- a/src/functionalTest/java/uk/gov/hmcts/reform/wacaseeventhandler/DlqMessagesToDatabaseTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/wacaseeventhandler/DlqMessagesToDatabaseTest.java
@@ -2,14 +2,16 @@ package uk.gov.hmcts.reform.wacaseeventhandler;
 
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.test.context.ActiveProfiles;
-import uk.gov.hmcts.reform.wacaseeventhandler.MessagingTests;
 import uk.gov.hmcts.reform.wacaseeventhandler.domain.ccd.message.EventInformation;
 import uk.gov.hmcts.reform.wacaseeventhandler.domain.model.CaseEventMessage;
 import uk.gov.hmcts.reform.wacaseeventhandler.domain.model.EventMessageQueryResponse;
 import uk.gov.hmcts.reform.wacaseeventhandler.entity.MessageState;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -22,6 +24,18 @@ import static org.junit.Assert.assertTrue;
 @Slf4j
 @ActiveProfiles(profiles = {"local", "functional"})
 public class DlqMessagesToDatabaseTest extends MessagingTests {
+
+    public static List<CaseEventMessage> caseEventMessages;
+
+    @BeforeEach
+    public void setup() {
+        caseEventMessages = new ArrayList<>();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        deleteMessagesFromDatabase(caseEventMessages);
+    }
 
     @Test
     public void should_store_dlq_messages_in_database() {
@@ -50,12 +64,11 @@ public class DlqMessagesToDatabaseTest extends MessagingTests {
                 () -> {
                     final EventMessageQueryResponse dlqMessagesFromDb = getMessagesFromDb(caseId, true);
                     if (dlqMessagesFromDb != null) {
-                        final List<CaseEventMessage> caseEventMessages = dlqMessagesFromDb.getCaseEventMessages();
+                        caseEventMessages = dlqMessagesFromDb.getCaseEventMessages();
 
                         assertEquals(messageIds.size(), caseEventMessages.size());
                         assertTrue(caseEventMessages.stream().allMatch(CaseEventMessage::getFromDlq));
 
-                        deleteMessagesFromDatabase(caseEventMessages);
                         return true;
                     } else {
                         return false;
@@ -85,12 +98,11 @@ public class DlqMessagesToDatabaseTest extends MessagingTests {
             .until(() -> {
                 final EventMessageQueryResponse dlqMessagesFromDb = getMessagesFromDb(caseId, true);
                 if (dlqMessagesFromDb != null) {
-                    final List<CaseEventMessage> caseEventMessages
-                        = dlqMessagesFromDb.getCaseEventMessages();
+                    caseEventMessages = dlqMessagesFromDb.getCaseEventMessages();
 
                     assertEquals(1, caseEventMessages.size());
                     assertEquals(MessageState.UNPROCESSABLE, caseEventMessages.get(0).getState());
-                    deleteMessagesFromDatabase(caseEventMessages);
+
                     return true;
                 } else {
                     return false;

--- a/src/integrationTest/java/uk/gov/hmcts/reform/wacaseeventhandler/query/FindProblemMessageTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/wacaseeventhandler/query/FindProblemMessageTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.wacaseeventhandler.query;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import uk.gov.hmcts.reform.wacaseeventhandler.repository.CaseEventMessageReposit
 import uk.gov.hmcts.reform.wacaseeventhandler.services.CaseEventMessageMapper;
 import uk.gov.hmcts.reform.wacaseeventhandler.services.jobservices.FindProblemMessageJob;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -29,6 +31,8 @@ public class FindProblemMessageTest {
 
     private FindProblemMessageJob findProblemMessageJob;
 
+    private List<String> caseEventMessages;
+
     @BeforeEach
     void setUp() {
         findProblemMessageJob = new FindProblemMessageJob(caseEventMessageRepository,
@@ -36,9 +40,14 @@ public class FindProblemMessageTest {
                                                           60);
     }
 
+    @AfterEach
+    void tearDown() {
+        caseEventMessages = new ArrayList<>();
+    }
+
     @Test
     void should_retrieve_an_ready_message() {
-        List<String> caseEventMessages = findProblemMessageJob.run();
+        caseEventMessages = findProblemMessageJob.run();
         Assertions.assertThat(caseEventMessages.isEmpty()).isFalse();
         Assertions.assertThat(caseEventMessages.size()).isEqualTo(3);
         Assertions.assertThat(caseEventMessages.get(0)).isEqualTo("ID:c05439ca-ddb2-47d0-a0a6-ba9db76a3064:58:1:1-10");


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1916


### Change description ###
case event list should be emptied between each test, and only deleted after tests are complete


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
