### PR TITLE
RWA-2288 CVE Updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.7.7'
   id 'org.owasp.dependencycheck' version '8.0.2'
-  id 'uk.gov.hmcts.java' version '0.12.5'
+  id 'uk.gov.hmcts.java' version '0.12.40'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.5.0.2730'
   id 'info.solidsoft.pitest' version '1.7.4'
@@ -222,7 +222,7 @@ dependencyManagement {
     dependency group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.68'
     dependency group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
     // CVE-2018-10237 - Unbounded memory allocation
-    dependencySet(group: 'com.google.guava', version: '30.1-jre') {
+    dependencySet(group: 'com.google.guava', version: '31.1-jre') {
       entry 'guava'
     }
     dependency group: 'commons-io', name: 'commons-io', version: '2.11.0'
@@ -231,7 +231,7 @@ dependencyManagement {
     dependency group: 'net.minidev', name: 'json-smart', version: '2.4.8'
 
     //CVE-2021-28170
-    dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'
+    dependency group: 'org.glassfish', name: 'jakarta.el', version: '4.0.2'
 
     //CVE-2021-42550
     dependencySet(group: 'ch.qos.logback', version: '1.2.10') {
@@ -365,7 +365,7 @@ dependencies {
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 
   implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.17.0'
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.10.2'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '6.0.4'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
   testImplementation libraries.junit5
@@ -383,13 +383,13 @@ dependencies {
   testImplementation group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
   testImplementation group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
   testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.16.2'
-  testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.16.2'
+  testImplementation group: 'org.testcontainers', name: 'junit-jupiter', version: '1.17.6'
 
   testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
   testImplementation group: 'info.solidsoft.gradle.pitest', name: 'gradle-pitest-plugin', version: '1.7.4'
   testImplementation group: 'org.codehaus.sonar-plugins', name: 'sonar-pitest-plugin', version: '0.5'
 
-  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.2.1', classifier: 'all'
+  testImplementation group: 'com.github.hmcts', name: 'fortify-client', version: '1.3.0', classifier: 'all'
   testImplementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.1'
 
   testUtilsImplementation sourceSets.main.runtimeClasspath
@@ -409,7 +409,7 @@ dependencies {
   implementation group: 'com.vladmihalcea', name: 'hibernate-types-52', version: '2.20.0'
 
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.10.3'
-  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.4.3'
+  runtimeOnly group: 'org.postgresql', name: 'postgresql', version: '42.5.3'
 }
 
 mainClassName = 'uk.gov.hmcts.reform.wacaseeventhandler.Application'


### PR DESCRIPTION
Bump uk.gov.hmcts.java from 0.12.5 to 0.12.40
Bump org.postgresql:postgresql from 42.4.3 to 42.5.3
Bump junit-jupiter from 1.16.2 to 1.17.6 
Bumps [jakarta.el](https://github.com/eclipse-ee4j/el-ri) from 4.0.1 to 4.0.2.
Bumps [launchdarkly-java-server-sdk](https://github.com/launchdarkly/java-server-sdk) from 5.10.2 to 6.0.4.
Bumps [fortify-client](https://github.com/hmcts/fortify-client) from 1.2.1 to 1.3.0.
Bumps [guava](https://github.com/google/guava) from 30.1-jre to 31.1-jre.
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
