### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,7 +312,7 @@ repositories {
 def versions = [
   junit        : '5.9.3',
   junitPlatform: '1.9.3',
-  reformLogging: '5.1.9',
+  reformLogging: '6.0.1',
   springDoc    : '1.7.0',
   springBoot   : '2.7.12',
   serenity     : '3.1.20',


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.